### PR TITLE
Add flag to switch stream source between Overpass and Onramp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -137,9 +137,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.768.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.768.0.tgz",
-      "integrity": "sha512-yIY1Fbj8kvyP3cEHOCvvw59IRqcYq84/aB0BGfuWPQzPVRjTYVxA8zP/iytM4Zo+NO8xkCq9Wc9OoMfwZZb+GQ==",
+      "version": "2.770.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.770.0.tgz",
+      "integrity": "sha512-CUkyXwFxEJ32AxH2tjBFfG4grjFdyDjyBaltYzaLa0U2KvGgDIj28q8psdxhALTm3c9zPEoMYpRXiTyRNmkROQ==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -629,8 +629,8 @@
       "integrity": "sha1-IK5BEwxIbkmjsqPCtYoUGcSYZ3g="
     },
     "osm-replication-streams": {
-      "version": "github:azavea/osm-replication-streams#ad6995b8a0900c8df84e1fa26171af58433c229c",
-      "from": "github:azavea/osm-replication-streams#ad6995b8a0900c8df84e1fa26171af58433c229c",
+      "version": "github:azavea/osm-replication-streams#c70a118b603f41dd583ffe9238178a2d91247a7a",
+      "from": "github:azavea/osm-replication-streams#c70a118b603f41dd583ffe9238178a2d91247a7a",
       "requires": {
         "@turf/helpers": "^6.1.4",
         "array-flat-polyfill": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -137,9 +137,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.697.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.697.0.tgz",
-      "integrity": "sha512-aNrwiPRHQyzjJxpfgLwVOevuGTOMkU5uiP4VDIngfc/k4s2kQgLSyhLSKmNTjbubHCHfs1sQQkP3RXK2Oi8Rbw==",
+      "version": "2.768.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.768.0.tgz",
+      "integrity": "sha512-yIY1Fbj8kvyP3cEHOCvvw59IRqcYq84/aB0BGfuWPQzPVRjTYVxA8zP/iytM4Zo+NO8xkCq9Wc9OoMfwZZb+GQ==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -291,9 +291,9 @@
       },
       "dependencies": {
         "domelementtype": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.2.tgz",
+          "integrity": "sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA=="
         },
         "entities": {
           "version": "2.0.3",
@@ -340,19 +340,19 @@
       "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
     },
     "es-abstract": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+      "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.0",
-        "is-regex": "^1.1.0",
-        "object-inspect": "^1.7.0",
+        "is-callable": "^1.2.2",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.8.0",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.0",
+        "object.assign": "^4.1.1",
         "string.prototype.trimend": "^1.0.1",
         "string.prototype.trimstart": "^1.0.1"
       }
@@ -457,9 +457,9 @@
       }
     },
     "id-area-keys": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/id-area-keys/-/id-area-keys-2.16.0.tgz",
-      "integrity": "sha512-OjVHV1a5D4Voba0NmT0Vb/XZMhVC8AXqc/dV5bWGSGxFQGbwR/pBS0eySR17+V9n0g7gb+y52r6EPXZwRf+O9w=="
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/id-area-keys/-/id-area-keys-2.17.3.tgz",
+      "integrity": "sha512-wcAi4NrAI6PlKtwWtbc/NWB/HBnTiXTmZvISJLcJiQREZKKPrk62iT6Oahh8gqiAjMrAQrJsXzAYVAzB3r5gyg=="
     },
     "ieee754": {
       "version": "1.1.13",
@@ -477,19 +477,24 @@
       "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
     },
     "is-callable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA=="
     },
     "is-date-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
       "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
     },
+    "is-negative-zero": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+      "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE="
+    },
     "is-regex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
-      "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -535,9 +540,9 @@
       "integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ="
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -560,9 +565,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "object-inspect": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -570,14 +575,35 @@
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
+      "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.0",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-negative-zero": "^2.0.0",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "object.getownpropertydescriptors": {
@@ -603,8 +629,8 @@
       "integrity": "sha1-IK5BEwxIbkmjsqPCtYoUGcSYZ3g="
     },
     "osm-replication-streams": {
-      "version": "github:azavea/osm-replication-streams#8996825887a57f64f3e3fdae94942b1b23df380e",
-      "from": "github:azavea/osm-replication-streams#8996825887a57f64f3e3fdae94942b1b23df380e",
+      "version": "github:azavea/osm-replication-streams#ad6995b8a0900c8df84e1fa26171af58433c229c",
+      "from": "github:azavea/osm-replication-streams#ad6995b8a0900c8df84e1fa26171af58433c229c",
       "requires": {
         "@turf/helpers": "^6.1.4",
         "array-flat-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "epipebomb": "^1.0.0",
     "fs-extra": "^8.0.1",
     "highland": "^2.13.4",
-    "osm-replication-streams": "azavea/osm-replication-streams#8996825887a57f64f3e3fdae94942b1b23df380e",
+    "osm-replication-streams": "github:azavea/osm-replication-streams#ad6995b8a0900c8df84e1fa26171af58433c229c",
     "yaml": "^1.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "epipebomb": "^1.0.0",
     "fs-extra": "^8.0.1",
     "highland": "^2.13.4",
-    "osm-replication-streams": "github:azavea/osm-replication-streams#ad6995b8a0900c8df84e1fa26171af58433c229c",
+    "osm-replication-streams": "github:azavea/osm-replication-streams#c70a118b603f41dd583ffe9238178a2d91247a7a",
     "yaml": "^1.6.0"
   }
 }


### PR DESCRIPTION
The two streams are compatible so this is just an inline flag. Users will also need to configure the ONRAMP_URL env variable instead of OVERPASS_URL.

## Testing

```
ONRAMP_URL="s3://bucket/path/to/onramp/diffs" \
    node index.js -s onramp -i 4222751 s3://bucket/path/to/output/
```

Generates the log:
```
4222751 (2020-09-22T18:06:00.000Z): 2850                                                                                                  
4222752 (2020-09-22T18:07:00.000Z): 290                                                                                                   
4222753 (2020-09-22T18:08:00.000Z): 119                                                                                                   
4222754 (2020-09-22T18:09:00.000Z): 1366                             
4222755 (2020-09-22T18:10:00.000Z): 58                                                                                                    
4222756 (2020-09-22T18:11:00.000Z): 466     
...
```

This PR depends on azavea/onramp#50 and azavea/osm-replication-streams#6

~~TODO: Merge PR dependencies first then update the package.json to point to azavea/osm-replication-streams commit on master.~~